### PR TITLE
Resolve Tag

### DIFF
--- a/testdata/tags/map/out.yml
+++ b/testdata/tags/map/out.yml
@@ -1,0 +1,6 @@
+input:
+    yp.yml: "--- #export\nitems:\n  - id: 123\n    name: bla\n!_ template:\n  id: !yq .id\n  name: !yq .name\n--- #out\n!map $ctx.items:\n    !_ <<: \n        !yq '$v.name + \".yml\"':\n            - !resolve $v $ctx.template"
+output:
+    bla.yml: |
+        id: 123
+        name: bla

--- a/testdata/tags/merge/merge.yml
+++ b/testdata/tags/merge/merge.yml
@@ -38,15 +38,14 @@ stdout: |
       probe:
         url: /override
         interval: 20s
-        timeout: 5s
     ---
     name: example 2
     backend:
+      host: override.com
       probe:
         url: /override
         interval: 30s
         timeout: 15s
-      host: example.com
       timeout: 1m
     ---
     backend:

--- a/testdata/tags/merge/multiple
+++ b/testdata/tags/merge/multiple
@@ -63,3 +63,7 @@ stdout: |
       c: 3
       d: 4
       e: 5
+    non-new:
+      a: "1"
+      b:
+        foo: bar

--- a/testdata/tags/resolve/simple.yml
+++ b/testdata/tags/resolve/simple.yml
@@ -1,0 +1,24 @@
+input:
+    yp.yml: |-
+        --- #export
+        ctx:
+          - id: 123
+            name: bla
+          - id: 321
+            name: foo
+        !_ template:
+          id: !yq .id
+          name: !yq .name
+        ---
+        output: !resolve .ctx[0] .template
+        !map '.ctx':
+            !_ <<:
+              !yq '"test/overlays/aws-digital/" + $v.id + "/dkp2/resources.yml"': !resolve $v .template
+output: {}
+stdout: |
+    test/overlays/aws-digital/123/dkp2/resources.yml:
+      id: 123
+      name: bla
+    test/overlays/aws-digital/321/dkp2/resources.yml:
+      id: 321
+      name: foo

--- a/yplib/tag_resolve.go
+++ b/yplib/tag_resolve.go
@@ -1,0 +1,44 @@
+package yplib
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+)
+
+func init() {
+	AddTagResolver("!resolve", resolveResolver)
+}
+
+func resolveResolver(rc ResolveContext) (*yqlib.CandidateNode, error) {
+	tokens := strings.Split(strings.TrimSpace(rc.Target.Value), " ")
+	if len(tokens) != 2 {
+		return nil, errors.New("expected 2 expressions")
+	}
+
+	ctx, err := yq(createContext(rc), tokens[0])
+	if err != nil {
+		return nil, err
+	}
+
+	partial, err := yq(createContext(rc), tokens[1])
+	if err != nil {
+		return nil, err
+	}
+
+	partialNode := &Node{
+		Dir:           rc.Node.Dir,
+		File:          rc.Node.File,
+		CandidateNode: partial,
+		tagNodes:      getTagNodes(partial),
+	}
+
+	clone := partialNode.Clone()
+	err = clone.Resolve(NewContextNode(ctx), rc.Vars, rc.Opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return clone.CandidateNode, nil
+}


### PR DESCRIPTION
## Summary
Adds a new `resolve` tag with test, and adds a failing `map` test

Example usage of resolve tag
`Create a file in this directory where you resolve !tmpl within $ctx.configMap with the the contents of $v`

```
...
--- #<<ref[]
- !inc/file './{{.APP}}/configs.yaml'
- ctx: !yq '.overlays | to_entries | map( .key as $env | .value | to_entries | map({"env": $env, "overlay": .key}+ .value)) | flatten'
...
--- #out
!map '$ctx.ctx':
    !_ <<:
      !yq '"test/" + $v.APP + "/foo/" + $v.env + "/" + $v.overlay + "/bar/resources.yml"': 
        - !resolve $v $ctx.configMap
```

## Proposed Changes
### Adds
- `yplib/tag_resolve.go`


## Notes
Fixed some `testdata`